### PR TITLE
add --force to run counterpartyd testnet server

### DIFF
--- a/dist/linux/runit/counterpartyd-testnet/run
+++ b/dist/linux/runit/counterpartyd-testnet/run
@@ -3,4 +3,4 @@
 USER=xcpd
 export USER_HOME=/home/xcp
 ulimit -n 4096
-exec su -s /bin/bash -c '/usr/local/bin/counterpartyd --data-dir=${USER_HOME}/.config/counterpartyd-testnet --testnet server' ${USER}
+exec su -s /bin/bash -c '/usr/local/bin/counterpartyd --data-dir=${USER_HOME}/.config/counterpartyd-testnet --testnet server --force' ${USER}


### PR DESCRIPTION
The new lock system in counterpartyd prevents to run twice the same application.
