### PR TITLE
Added 2 deps

### DIFF
--- a/run.py
+++ b/run.py
@@ -351,9 +351,12 @@ def do_counterparty_setup(run_as_user, backend_rpc_password, backend_rpc_passwor
     
     def install_dependencies():
         runcmd("apt-get -y update")
-        runcmd("apt-get -y install runit build-essential software-properties-common python-software-properties \
-        git-core wget python3 python3-setuptools python3-dev python3-pip python3-pytest python3-sphinx \
-        python3-zmq  python3-apsw python-virtualenv libsqlite3-dev libgmp-dev libleveldb-dev")
+        runcmd("apt-get -y install runit build-essential \
+        software-properties-common python-software-properties \
+        git-core wget python3 python3-setuptools python3-dev \
+        python3-pip python3-pytest python3-sphinx \
+        python3-zmq  python3-apsw python-virtualenv \
+        libsqlite3-dev libgmp-dev libleveldb-dev")
         
         if questions.with_counterblock:
             #counterblockd currently uses Python 2.7 due to gevent-socketio's lack of support for Python 3

--- a/run.py
+++ b/run.py
@@ -351,8 +351,9 @@ def do_counterparty_setup(run_as_user, backend_rpc_password, backend_rpc_passwor
     
     def install_dependencies():
         runcmd("apt-get -y update")
-        runcmd("apt-get -y install runit software-properties-common python-software-properties git-core wget \
-        python3 python3-setuptools python3-dev python3-pip build-essential python3-sphinx python-virtualenv libsqlite3-dev python3-apsw python3-zmq")
+        runcmd("apt-get -y install runit build-essential software-properties-common python-software-properties \
+        git-core wget python3 python3-setuptools python3-dev python3-pip python3-pytest python3-sphinx \
+        python3-zmq  python3-apsw python-virtualenv libsqlite3-dev libgmp-dev libleveldb-dev")
         
         if questions.with_counterblock:
             #counterblockd currently uses Python 2.7 due to gevent-socketio's lack of support for Python 3


### PR DESCRIPTION
Sometimes certain Python 3 modules can be missing and interrupt the build. This is to preempt such errors:

* pytest module - (https://github.com/CounterpartyXCP/counterparty-lib/issues/872)
 * Ubuntu 14.04 - package python3-pytest, exists 
 * Ubuntu 16.04 - package python3-pytest, exists
* plyvel module - (https://github.com/CounterpartyXCP/counterparty-lib/issues/841)
 * Ubuntu 14.04 - package libleveldb-dev, exists 
 * Ubuntu 16.04 - package libleveldb-dev, exists
* GMP lib header - (not mandatory, but removes a warning when pycrypto is built)
 * Ubuntu 14.04 - package libgmp-dev, exists 
 * Ubuntu 16.04 - package libgmp-dev, exists