### PR TITLE
logname=>whoami

### DIFF
--- a/fednode.py
+++ b/fednode.py
@@ -135,7 +135,7 @@ def setup_env():
     global SUDO_CMD
     if os.name != 'nt':
         IS_WINDOWS = False
-        SESSION_USER = subprocess.check_output("logname", shell=True).decode("utf-8").strip()
+        SESSION_USER = subprocess.check_output("whoami", shell=True).decode("utf-8").strip()
         assert SESSION_USER
         SUDO_CMD = "sudo -E"
         IS_SUDO_ACTIVE = subprocess.check_output('sudo -n uptime 2>&1|grep "load"|wc -l', shell=True).decode("utf-8").strip() == "1"


### PR DESCRIPTION
I haven't verified the solution, but logname doesn't work for some (it seems when the installer executed from a X-Windows terminal, while running from "pure" shell does work).
Ref:
https://bugs.launchpad.net/ubuntu/+source/gnome-terminal/+bug/1537645
and 
https://counterpartytalk.org/t/fednode-install-error/2350
