### PR TITLE
Remove non used code

### DIFF
--- a/fednode.py
+++ b/fednode.py
@@ -59,7 +59,7 @@ CONFIGCHECK_FILES_BASE_EXTERNAL_BITCOIN = [
     ['counterparty', 'client.testnet.conf.default', 'client.testnet.conf'],
     ['counterparty', 'server.conf.default', 'server.conf'],
     ['counterparty', 'server.testnet.conf.default', 'server.testnet.conf'],
-];
+]
 CONFIGCHECK_FILES_BASE = [
     ['bitcoin', 'bitcoin.conf.default', 'bitcoin.conf'],
     ['bitcoin', 'bitcoin.testnet.conf.default', 'bitcoin.testnet.conf'],
@@ -69,12 +69,12 @@ CONFIGCHECK_FILES_BASE = [
     ['counterparty', 'client.testnet.conf.default', 'client.testnet.conf'],
     ['counterparty', 'server.conf.default', 'server.conf'],
     ['counterparty', 'server.testnet.conf.default', 'server.testnet.conf'],
-];
+]
 CONFIGCHECK_FILES_COUNTERBLOCK = CONFIGCHECK_FILES_BASE + [
     ['counterblock', 'server.conf.default', 'server.conf'],
     ['counterblock', 'server.testnet.conf.default', 'server.testnet.conf'],
 ]
-CONFIGCHECK_FILES_FULL = CONFIGCHECK_FILES_COUNTERBLOCK;
+CONFIGCHECK_FILES_FULL = CONFIGCHECK_FILES_COUNTERBLOCK
 CONFIGCHECK_FILES = {
     'base_extbtc': CONFIGCHECK_FILES_BASE_EXTERNAL_BITCOIN,
     'base': CONFIGCHECK_FILES_BASE,
@@ -231,14 +231,14 @@ def config_check(build_config):
         try:
             fromfilepath = os.path.join(SCRIPTDIR, 'config', dirname, fromfile)
             fromdate = file_mtime(fromfilepath)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             print("Config file not found at {}".format(fromfilepath))
             continue
 
         try:
             tofilepath = os.path.join(SCRIPTDIR, 'config', dirname, tofile)
             todate = file_mtime(tofilepath)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             print("Config file not found at {}".format(tofilepath))
             continue
 


### PR DESCRIPTION
1. In python``;`` is deprecated.
2. It didn't use ``e`` after ``as e``.